### PR TITLE
修复因localEngine.min.js文件不存在导致的加载错误

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -35,9 +35,9 @@ function loadMusicScript() {
     script.src = './js/Meting2.min.js';
     document.body.appendChild(script);
   } else {
-    // 否则加载 localEngine.min.js
+    // 否则加载 localEngine.js
     var script = document.createElement('script');
-    script.src = './js/localEngine.min.js';
+    script.src = './js/localEngine.js';
     document.body.appendChild(script);
     local = true;
   }


### PR DESCRIPTION
修复了因localEngine.min.js文件不存在，而main.js未修改引入文件名称导致localMusic无法正常加载的错误