### PR TITLE
新增setupMediaSessionHandlers方法，响应 MediaSession 标准媒体交互

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 /music/
 musiclist.json
+node_modules

--- a/js/Meting.js
+++ b/js/Meting.js
@@ -130,6 +130,8 @@ class MetingJSElement extends HTMLElement {
     this.appendChild(div)
 
     this.aplayer = new APlayer(options)
+
+    heo.setupMediaSessionHandlers(this.aplayer);
   }
 
 }

--- a/js/localEngine.js
+++ b/js/localEngine.js
@@ -19,3 +19,5 @@ const ap = new APlayer({
   lrcType: 3,
   audio: encodedLocalMusic
 });
+
+heo.setupMediaSessionHandlers(ap);

--- a/js/main.js
+++ b/js/main.js
@@ -200,6 +200,76 @@ var heo = {
         });
     }
   },
+  // 响应 MediaSession 标准媒体交互
+  setupMediaSessionHandlers: function (aplayer) {
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.setActionHandler('play', () => {
+        aplayer.play();
+      });
+
+      navigator.mediaSession.setActionHandler('pause', () => {
+        aplayer.pause();
+      });
+
+      navigator.mediaSession.setActionHandler('seekbackward', () => {
+        aplayer.seek(aplayer.audio.currentTime -= 10);
+      });
+
+      navigator.mediaSession.setActionHandler('seekforward', () => {
+        aplayer.seek(aplayer.audio.currentTime += 10);
+      });
+
+      navigator.mediaSession.setActionHandler('previoustrack', () => {
+        aplayer.skipBack();
+      });
+
+      navigator.mediaSession.setActionHandler('nexttrack', () => {
+        aplayer.skipForward();
+      });
+
+      // 更新 Media Session 元数据
+      aplayer.on('loadeddata', () => {
+        const audio = aplayer.list.audios[aplayer.list.index]
+        console.log("播放歌曲名称：", audio.name);
+        console.log("播放歌曲歌手：", audio.artist);
+
+        const coverUrl = audio.cover || './img/icon.png';
+        console.log("播放歌曲封面：", coverUrl);
+
+        if ('mediaSession' in navigator) {
+          navigator.mediaSession.metadata = new MediaMetadata({
+            title: audio.name,
+            artist: audio.artist,
+            album: audio.album,
+            artwork: [
+              { src: coverUrl, sizes: '96x96', type: 'image/jpeg' },
+              { src: coverUrl, sizes: '128x128', type: 'image/jpeg' },
+              { src: coverUrl, sizes: '192x192', type: 'image/jpeg' },
+              { src: coverUrl, sizes: '256x256', type: 'image/jpeg' },
+              { src: coverUrl, sizes: '384x384', type: 'image/jpeg' },
+              { src: coverUrl, sizes: '512x512', type: 'image/jpeg' }
+            ]
+          });
+        } else {
+          console.log('当前浏览器不支持 Media Session API');
+          document.title = `${audio.name} - ${audio.artist}`;
+        }
+      });
+
+      // 更新播放状态
+      aplayer.on('play', () => {
+        if ('mediaSession' in navigator) {
+          navigator.mediaSession.playbackState = 'playing';
+        }
+      });
+
+      aplayer.on('pause', () => {
+        if ('mediaSession' in navigator) {
+          navigator.mediaSession.playbackState = 'paused';
+        }
+      });
+    }
+  }
 }
 
 // 调用


### PR DESCRIPTION
添加如 iOS 锁屏音乐控件、Chrome 媒体播放控制等功能。（`APlayer` 目前没有获取正在滚动的歌词的通用方法，暂时还没加歌词，再研究下……）

**- Chrome**
![screenshot-20241127-164645](https://github.com/user-attachments/assets/5da73e3a-2f1c-42bb-8e78-ef1f7d6ff02d)
![20241127-162934](https://github.com/user-attachments/assets/07307a89-7293-4afb-8f54-929d85e7a8ea)

**- iOS**
![页面_1-1](https://github.com/user-attachments/assets/43abb430-a9fa-41ce-8be3-b4e556eb8a4d)
![页面_2-1](https://github.com/user-attachments/assets/38834920-62b1-48f1-992e-39669adcff68)
